### PR TITLE
fix(audit): post-audit hardening — routes, FP filter, i18n

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -277,6 +277,8 @@ function App() {
               />
               <Route path="temporal" element={<Navigate to="/administrations" replace />} />
               <Route path="institutions/health" element={<Navigate to="/institutions" replace />} />
+              <Route path="price-intelligence" element={<Navigate to="/price-analysis" replace />} />
+              <Route path="model-transparency" element={<Navigate to="/model" replace />} />
               <Route
                 path="price-analysis"
                 element={

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { motion } from 'framer-motion'
 import { fadeIn } from '@/lib/animations'
+import { useTranslation } from 'react-i18next'
 
 // SVG Illustrations for different states
 const NoDataIllustration = () => (
@@ -192,16 +193,17 @@ export function NoResultsState({
   hasFilters?: boolean
   onClearFilters?: () => void
 }) {
+  const { t } = useTranslation('common')
   return (
     <EmptyState
       variant="no-results"
-      title={`No ${entityName} found`}
+      title={t('emptyState.noFoundTitle', { name: entityName })}
       description={
         hasFilters
-          ? 'Try adjusting your filters to see more results.'
-          : `No ${entityName} are available in the database.`
+          ? t('emptyState.adjustFilters')
+          : t('emptyState.noFoundDesc', { name: entityName })
       }
-      actionLabel={hasFilters ? 'Clear all filters' : undefined}
+      actionLabel={hasFilters ? t('emptyState.clearAllFilters') : undefined}
       onAction={onClearFilters}
     />
   )
@@ -216,16 +218,17 @@ export function ErrorState({
   onRetry?: () => void
   loading?: boolean
 }) {
+  const { t } = useTranslation('common')
   return (
     <EmptyState
       variant="error"
-      title="Something went wrong"
+      title={t('emptyState.errorTitle')}
       description={
         message === 'Network Error'
-          ? 'Unable to connect to server. Please check if the backend is running.'
-          : message || 'An unexpected error occurred.'
+          ? t('emptyState.networkError')
+          : message || t('emptyState.unexpectedError')
       }
-      actionLabel="Try again"
+      actionLabel={t('emptyState.tryAgain')}
       onAction={onRetry}
       loading={loading}
     />
@@ -237,12 +240,13 @@ export function LoadingTimeoutState({
 }: {
   onRetry?: () => void
 }) {
+  const { t } = useTranslation('common')
   return (
     <EmptyState
       variant="error"
-      title="Loading is taking longer than expected"
-      description="The data might still be loading. You can wait or try again."
-      actionLabel="Retry"
+      title={t('emptyState.slowTitle')}
+      description={t('emptyState.slowDesc')}
+      actionLabel={t('retry')}
       onAction={onRetry}
     />
   )
@@ -253,11 +257,12 @@ export function ComingSoonState({
 }: {
   featureName: string
 }) {
+  const { t } = useTranslation('common')
   return (
     <EmptyState
       variant="coming-soon"
-      title={`${featureName} Coming Soon`}
-      description="This feature is currently under development and will be available in a future update."
+      title={t('emptyState.comingSoonTitle', { name: featureName })}
+      description={t('emptyState.comingSoonDesc')}
     />
   )
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -425,6 +425,20 @@
     "noData": "No data available.",
     "noResults": "No results match the current filters."
   },
+  "emptyState": {
+    "errorTitle": "Something went wrong",
+    "networkError": "Unable to connect to the server. Please check your connection.",
+    "unexpectedError": "An unexpected error occurred.",
+    "tryAgain": "Try again",
+    "slowTitle": "Loading is taking longer than expected",
+    "slowDesc": "The data might still be loading. You can wait or try again.",
+    "comingSoonTitle": "{{name}} Coming Soon",
+    "comingSoonDesc": "This feature is currently under development and will be available in a future update.",
+    "noFoundTitle": "No {{name}} found",
+    "noFoundDesc": "No {{name}} are available in the database.",
+    "adjustFilters": "Try adjusting your filters to see more results.",
+    "clearAllFilters": "Clear all filters"
+  },
   "impacto": {
     "label": "This amount is equivalent to:",
     "imssAnnualSalaries": "IMSS annual salaries",

--- a/frontend/src/i18n/locales/es/aria.json
+++ b/frontend/src/i18n/locales/es/aria.json
@@ -230,7 +230,7 @@
     "lastContract": "Último contrato: {{year}}"
   },
   "burst": {
-    "label": "Burst"
+    "label": "Ráfaga"
   },
   "topInstitution": {
     "label": "Cliente principal",

--- a/frontend/src/i18n/locales/es/common.json
+++ b/frontend/src/i18n/locales/es/common.json
@@ -427,6 +427,20 @@
     "copyLink": "Copiar enlace",
     "template": "🔍 {{summary}} — RUBLI Inteligencia de Contrataciones: {{url}}"
   },
+  "emptyState": {
+    "errorTitle": "Algo salió mal",
+    "networkError": "No se puede conectar al servidor. Por favor verifica tu conexión.",
+    "unexpectedError": "Ocurrió un error inesperado.",
+    "tryAgain": "Intentar de nuevo",
+    "slowTitle": "La carga está tardando más de lo esperado",
+    "slowDesc": "Los datos aún podrían estar cargando. Puedes esperar o intentar de nuevo.",
+    "comingSoonTitle": "{{name}} próximamente",
+    "comingSoonDesc": "Esta función está en desarrollo y estará disponible en una actualización futura.",
+    "noFoundTitle": "No se encontraron {{name}}",
+    "noFoundDesc": "No hay {{name}} disponibles en la base de datos.",
+    "adjustFilters": "Intenta ajustar los filtros para ver más resultados.",
+    "clearAllFilters": "Limpiar todos los filtros"
+  },
   "errors": {
     "couldNotLoad": "No se pudo cargar esta sección. Intenta refrescar la página.",
     "failedToSubmit": "Error al enviar — por favor intenta de nuevo.",

--- a/frontend/src/i18n/locales/es/price.json
+++ b/frontend/src/i18n/locales/es/price.json
@@ -47,7 +47,7 @@
   "filterBySector": "Filtrar por sector",
   "filterAriaLabel": "Filtro de sector",
   "allSectors": "Todos",
-  "statsOutliers": "Total outliers",
+  "statsOutliers": "Total de anomalías",
   "statsValueAtRisk": "Valor en riesgo",
   "statsAvgZ": "Z-score prom.",
   "statsMaxZ": "Z-score máx.",


### PR DESCRIPTION
- App.tsx: add redirects /price-intelligence→/price-analysis, /model-transparency→/model
- EmptyState.tsx: i18n all helper components (NoResultsState, ErrorState, LoadingTimeoutState, ComingSoonState) using new common.emptyState keys
- en/common.json: add emptyState.* key group (12 keys)
- es/common.json: add emptyState.* key group with Spanish translations
- es/price.json: statsOutliers "Total outliers" → "Total de anomalías"
- es/aria.json: burst.label "Burst" → "Ráfaga"
- RUBLI_NORMALIZED.db + RUBLI_DEPLOY.db: insert GTF FP entry for vendor 4332 (BAXTER,S.A. DE C.V.) so investigation FP filter works correctly

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>